### PR TITLE
return error instead of console.error

### DIFF
--- a/metabase.js
+++ b/metabase.js
@@ -60,8 +60,7 @@ const Metabase = {
             await setItem('metabaseUrl', metabaseUrl)
             return id
         } catch (error) {
-            console.error(error)
-            return false
+            return error
         }
     },
     /**
@@ -107,7 +106,7 @@ const Metabase = {
             const response = await request.json()
             return response
         } catch (error) {
-            console.error(error)
+            return error
         }
     },
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-metabase-auth",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Manage sessions and make requests to Metabase instances in React Native apps.",
   "main": "metabase.js",
   "repository": "git@github.com:kdoh/react-native-metabase-auth",


### PR DESCRIPTION
Fixes #5 

`console.error` is probably the wrong way to handle invalid auth or other issues in this package, so rather than using the console, just return the error so others can figure out what they want to do with it.